### PR TITLE
Add LimitConcurrency support for Backend section

### DIFF
--- a/src/Oriflame.PolicyBuilder.Policies/Builders/Fluent/Sections/IBackendSectionPolicyBuilder.cs
+++ b/src/Oriflame.PolicyBuilder.Policies/Builders/Fluent/Sections/IBackendSectionPolicyBuilder.cs
@@ -7,6 +7,9 @@ namespace Oriflame.PolicyBuilder.Policies.Builders.Fluent.Sections
 {
     public interface IBackendSectionPolicyBuilder : IPolicySectionBuilder<IBackendSectionPolicyBuilder>
     {
+        /// <see href="https://docs.microsoft.com/en-us/azure/api-management/api-management-advanced-policies#LimitConcurrency"/>
+        IBackendSectionPolicyBuilder LimitConcurrency(string key, int maxCount, Func<IBackendSectionPolicyBuilder, ISectionPolicy> action);
+
         /// <see href="https://docs.microsoft.com/en-us/azure/api-management/api-management-transformation-policies#SetBackendService"/>
         IBackendSectionPolicyBuilder SetBackendService(string url);
 

--- a/src/Oriflame.PolicyBuilder.Xml/Builders/Sections/BackendSectionPolicyBuilder.cs
+++ b/src/Oriflame.PolicyBuilder.Xml/Builders/Sections/BackendSectionPolicyBuilder.cs
@@ -15,6 +15,14 @@ namespace Oriflame.PolicyBuilder.Xml.Builders.Sections
         }
 
         /// <inheritdoc />
+        public IBackendSectionPolicyBuilder LimitConcurrency(string key, int maxCount, Func<IBackendSectionPolicyBuilder, ISectionPolicy> action)
+        {
+            var limitConcurrency = new LimitConcurrency(key, maxCount);
+            var innerPolicyBuilder = new BackendSectionPolicyBuilder(limitConcurrency);
+            return AddPolicyDefinition(action.Invoke(innerPolicyBuilder));
+        }
+
+        /// <inheritdoc />
         public virtual IBackendSectionPolicyBuilder SetBackendService(string url)
         {
             return AddPolicyDefinition(new SetBackendService(url));


### PR DESCRIPTION
Added support for limit concurrency in backend section - see [documentation](https://docs.microsoft.com/en-us/azure/api-management/api-management-advanced-policies#example-5)