### PR TITLE
Feature/added overload for policy builder

### DIFF
--- a/src/Oriflame.PolicyBuilder.Policies/Builders/Extensions/PolicyBuilderExtensions.cs
+++ b/src/Oriflame.PolicyBuilder.Policies/Builders/Extensions/PolicyBuilderExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Oriflame.PolicyBuilder.Policies.Builders.Fluent.Policy;
+﻿using System;
+using Oriflame.PolicyBuilder.Policies.Builders.Fluent.Policy;
 
 namespace Oriflame.PolicyBuilder.Policies.Builders.Extensions
 {
@@ -6,22 +7,38 @@ namespace Oriflame.PolicyBuilder.Policies.Builders.Extensions
     {
         public static IPolicyBuilderTerminator RewriteUri(this IPolicyBuilder policyBuilder, string uri)
         {
-            return policyBuilder
-                .Inbound(builder => builder.BaseWithRewriteUri(uri))
-                .Backend()
+            return policyBuilder.RewriteUri(uri, b => b.Backend());
+        }
+
+        public static IPolicyBuilderTerminator RewriteUri(this IPolicyBuilder policyBuilder, string uri, Func<IBackendPolicyBuilder, IOutboundPolicyBuilder> buildBackendSection)
+        {
+            var backendPolicyBuilder = policyBuilder
+                .Inbound(builder => builder.BaseWithRewriteUri(uri));
+
+            var outboundPolicyBuilder = buildBackendSection.Invoke(backendPolicyBuilder);
+
+            return outboundPolicyBuilder
                 .Outbound()
                 .OnError();
         }
 
         public static IPolicyBuilderTerminator SetBackendService(this IPolicyBuilder policyBuilder, string domain)
         {
-            return policyBuilder
+            return policyBuilder.SetBackendService(domain, b => b.Backend());
+        }
+
+        public static IPolicyBuilderTerminator SetBackendService(this IPolicyBuilder policyBuilder, string domain, Func<IBackendPolicyBuilder, IOutboundPolicyBuilder> buildBackendSection)
+        {
+            var backendPolicyBuilder = policyBuilder
                 .Inbound(builder => builder
                     .Base()
                     .SetBackendService(domain)
                     .Create()
-                )
-                .Backend()
+                );
+
+            var outboundPolicyBuilder = buildBackendSection.Invoke(backendPolicyBuilder);
+
+            return outboundPolicyBuilder
                 .Outbound()
                 .OnError();
         }
@@ -29,11 +46,20 @@ namespace Oriflame.PolicyBuilder.Policies.Builders.Extensions
         public static IPolicyBuilderTerminator SetBackendAndRewriteUri(this IPolicyBuilder policyBuilder, string domain,
             string uri)
         {
-            return policyBuilder
+            return policyBuilder.SetBackendAndRewriteUri(domain, uri, b => b.Backend());
+        }
+
+        public static IPolicyBuilderTerminator SetBackendAndRewriteUri(this IPolicyBuilder policyBuilder, string domain,
+            string uri, Func<IBackendPolicyBuilder, IOutboundPolicyBuilder> buildBackendSection)
+        {
+            var backendPolicyBuilder = policyBuilder
                 .Inbound(builder => builder
                     .Base()
-                    .SetBackendAndRewriteUri(domain, uri))
-                .Backend()
+                    .SetBackendAndRewriteUri(domain, uri));
+
+            var outboundPolicyBuilder = buildBackendSection.Invoke(backendPolicyBuilder);
+                
+            return outboundPolicyBuilder
                 .Outbound()
                 .OnError();
         }

--- a/tests/Oriflame.PolicyBuilder.Xml.Tests/Integration/PolicyBuilderExtensionsTest.cs
+++ b/tests/Oriflame.PolicyBuilder.Xml.Tests/Integration/PolicyBuilderExtensionsTest.cs
@@ -1,0 +1,169 @@
+﻿using FluentAssertions;
+using Oriflame.PolicyBuilder.Policies.Builders;
+using Oriflame.PolicyBuilder.Policies.Builders.Extensions;
+using Oriflame.PolicyBuilder.Xml.Definitions.Sections;
+using Xunit;
+
+namespace Oriflame.PolicyBuilder.Xml.Tests.Integration
+{
+    public class PolicyBuilderExtensionsTest
+    {
+        [Fact]
+        public void RewriteUriCreatesCorrectPolicy()
+        {
+            // Assign
+            var uri = "/api/ping";
+            var policy = GetPolicyBuilder();
+
+            // Act
+            policy.PolicyBuilder.RewriteUri(uri);
+
+            // Assert
+            policy.Policy.GetXml().ToString().Should().Be(GetRewriteUrlPolicy(uri));
+        }
+
+        [Fact]
+        public void RewriteUriWithBackendSectionOverrideCreatesCorrectPolicy()
+        {
+            // Assign
+            var uri = "/api/ping";
+            var policy = GetPolicyBuilder();
+
+            // Act
+            policy.PolicyBuilder.RewriteUri(uri, b => b.Backend());
+
+            // Assert
+            policy.Policy.GetXml().ToString().Should().Be(GetRewriteUrlPolicy(uri));
+        }
+
+        [Fact]
+        public void SetBackendServiceCreatesCorrectPolicy()
+        {
+            // Assign
+            var domain = "http://test.ori";
+            var policy = GetPolicyBuilder();
+
+            // Act
+            policy.PolicyBuilder.SetBackendService(domain);
+
+            // Assert
+            policy.Policy.GetXml().ToString().Should().Be(GetSetBackendPolicy(domain));
+        }
+
+        [Fact]
+        public void SetBackendServiceWithBackendSectionOverrideCreatesCorrectPolicy()
+        {
+            // Assign
+            var domain = "http://test.ori";
+            var policy = GetPolicyBuilder();
+
+            // Act
+            policy.PolicyBuilder.SetBackendService(domain, b => b.Backend());
+
+            // Assert
+            policy.Policy.GetXml().ToString().Should().Be(GetSetBackendPolicy(domain));
+        }
+
+        [Fact]
+        public void SetBackendAndRewriteUriCreatesCorrectPolicy()
+        {
+            // Assign
+            var domain = "http://test.ori";
+            var uri = "/api/ping";
+            var policy = GetPolicyBuilder();
+
+            // Act
+            policy.PolicyBuilder.SetBackendAndRewriteUri(domain, uri);
+
+            // Assert
+            policy.Policy.GetXml().ToString().Should().Be(GetSetBackendAndRewriteUriPolicy(domain, uri));
+        }
+
+        [Fact]
+        public void SetBackendAndRewriteUriWithBackendSectionOverrideCreatesCorrectPolicy()
+        {
+            // Assign
+            var domain = "http://test.ori";
+            var uri = "/api/ping";
+            var policy = GetPolicyBuilder();
+
+            // Act
+            policy.PolicyBuilder.SetBackendAndRewriteUri(domain, uri, b => b.Backend());
+
+            // Assert
+            policy.Policy.GetXml().ToString().Should().Be(GetSetBackendAndRewriteUriPolicy(domain, uri));
+        }
+
+        private static string GetRewriteUrlPolicy(string uri)
+        {
+            return @$"<policies>
+  <inbound>
+    <base />
+    <rewrite-uri template=""{uri}"" />
+  </inbound>
+  <backend>
+    <base />
+  </backend>
+  <outbound>
+    <base />
+  </outbound>
+  <on-error>
+    <base />
+  </on-error>
+</policies>";
+        }
+        private static string GetSetBackendPolicy(string domain)
+        {
+            return @$"<policies>
+  <inbound>
+    <base />
+    <set-backend-service base-url=""{domain}"" />
+  </inbound>
+  <backend>
+    <base />
+  </backend>
+  <outbound>
+    <base />
+  </outbound>
+  <on-error>
+    <base />
+  </on-error>
+</policies>";
+        }
+
+        private static string GetSetBackendAndRewriteUriPolicy(string domain, string uri)
+        {
+            return @$"<policies>
+  <inbound>
+    <base />
+    <set-backend-service base-url=""{domain}"" />
+    <rewrite-uri template=""{uri}"" />
+  </inbound>
+  <backend>
+    <base />
+  </backend>
+  <outbound>
+    <base />
+  </outbound>
+  <on-error>
+    <base />
+  </on-error>
+</policies>";
+        }
+
+        private static (IPolicyBuilder PolicyBuilder, XmlOperationPolicy Policy) GetPolicyBuilder()
+        {
+            var buildersFactory = new XmlPolicyBuildersFactory();
+
+            var policy = buildersFactory.CreateOperationPolicy();
+            var policyBuilder = new Policies.Builders.PolicyBuilder(
+                buildersFactory.CreateInboundBuilder(policy),
+                buildersFactory.CreateBackendBuilder(policy),
+                buildersFactory.CreateOutboundBuilder(policy),
+                buildersFactory.CreateOnErrorBuilder(policy),
+                policy);
+
+            return (policyBuilder, policy);
+        }
+    }
+}


### PR DESCRIPTION
Added overloads for `IPolicyBuilder` which supports passing delegates for generating `IOutboundPolicyBuilder` from `IBackendPolicyBuilder`
- `RewriteUri(this IPolicyBuilder policyBuilder, string uri, Func<IBackendPolicyBuilder, IOutboundPolicyBuilder> buildBackendSection)`
- `SetBackendService(this IPolicyBuilder policyBuilder, string domain, Func<IBackendPolicyBuilder, IOutboundPolicyBuilder> buildBackendSection)`
- `SetBackendAndRewriteUri(this IPolicyBuilder policyBuilder, string domain, string uri, Func<IBackendPolicyBuilder, IOutboundPolicyBuilder> buildBackendSection)`