### PR TITLE
SendRequest - support string timeout values

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,9 @@
+# Change log
+
+## 3.0.1
+
+- `SendRequest` policy extension - `timeout` parameter can be defined as string
+
+## 3.0.0
+
+- The PolicyBuilder repo is being versioned by tags with semantic versioning.

--- a/directory.build.props
+++ b/directory.build.props
@@ -7,10 +7,10 @@
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>>https://github.com/Oriflame/PolicyBuilder</PackageProjectUrl>
     <Description>Policies generator for Azure API Management</Description>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.0.1</VersionPrefix>
     <VersionSuffix Condition="'$(VersionSuffix)'!=''">$(VersionSuffix)</VersionSuffix>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.0.0.0</FileVersion>
+    <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
+    <FileVersion>$(VersionPrefix)</FileVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 </Project>

--- a/src/Oriflame.PolicyBuilder.Policies/Builders/Extensions/SendRequestAttributesBuilderExtensions.cs
+++ b/src/Oriflame.PolicyBuilder.Policies/Builders/Extensions/SendRequestAttributesBuilderExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Oriflame.PolicyBuilder.Policies.Builders.Enums;
 using Oriflame.PolicyBuilder.Policies.Builders.Fluent.Attributes;
+using Oriflame.PolicyBuilder.Policies.Extensions;
 
 namespace Oriflame.PolicyBuilder.Policies.Builders.Extensions
 {
@@ -9,9 +10,14 @@ namespace Oriflame.PolicyBuilder.Policies.Builders.Extensions
     {
         public static IDictionary<string, string> Create(this ISendRequestAttributesBuilder builder, string variableName, TimeSpan timeOut, bool ignoreError = false, RequestMode requestMode = RequestMode.New)
         {
+            return Create(builder, variableName, timeOut.GetSeconds(), ignoreError, requestMode);
+        }
+
+        public static IDictionary<string, string> Create(this ISendRequestAttributesBuilder builder, string variableName, string timeoutValue, bool ignoreError = false, RequestMode requestMode = RequestMode.New)
+        {
             return builder.Mode(requestMode)
                 .ResponseVariable(variableName)
-                .Timeout(timeOut)
+                .Timeout(timeoutValue)
                 .IgnoreError(ignoreError)
                 .Create();
         }

--- a/src/Oriflame.PolicyBuilder.Policies/Builders/Extensions/SendRequestExtensions.cs
+++ b/src/Oriflame.PolicyBuilder.Policies/Builders/Extensions/SendRequestExtensions.cs
@@ -3,6 +3,7 @@ using Oriflame.PolicyBuilder.Policies.Builders.Enums;
 using Oriflame.PolicyBuilder.Policies.Builders.Fluent.Actions;
 using Oriflame.PolicyBuilder.Policies.Builders.Fluent.Sections;
 using Oriflame.PolicyBuilder.Policies.Definitions;
+using Oriflame.PolicyBuilder.Policies.Extensions;
 
 namespace Oriflame.PolicyBuilder.Policies.Builders.Extensions
 {
@@ -10,17 +11,32 @@ namespace Oriflame.PolicyBuilder.Policies.Builders.Extensions
     {
         public static T SendRequest<T>(this ISendRequest<T> builder, string variableName, TimeSpan timeout, Func<ISendRequestSectionBuilder, ISectionPolicy> sendRequestBuilder) where T : IPolicySectionBuilder
         {
-            return builder.SendRequest(attributesBuilder => attributesBuilder.Create(variableName, timeout), sendRequestBuilder);
+            return builder.SendRequest(variableName, timeout.GetSeconds(), sendRequestBuilder);
         }
 
         public static T SendRequest<T>(this ISendRequest<T> builder, string variableName, TimeSpan timeout, bool ignoreError, Func<ISendRequestSectionBuilder, ISectionPolicy> sendRequestBuilder) where T : IPolicySectionBuilder
         {
-            return builder.SendRequest(attributesBuilder => attributesBuilder.Create(variableName, timeout, ignoreError), sendRequestBuilder);
+            return builder.SendRequest(variableName, timeout.GetSeconds(), ignoreError, sendRequestBuilder);
         }
 
         public static T SendRequest<T>(this ISendRequest<T> builder, string variableName, TimeSpan timeout, bool ignoreError, RequestMode requestMode, Func<ISendRequestSectionBuilder, ISectionPolicy> sendRequestBuilder) where T : IPolicySectionBuilder
         {
-            return builder.SendRequest(attributesBuilder => attributesBuilder.Create(variableName, timeout, ignoreError, requestMode), sendRequestBuilder);
+            return builder.SendRequest(variableName, timeout.GetSeconds(), ignoreError, requestMode, sendRequestBuilder);
+        }
+
+        public static T SendRequest<T>(this ISendRequest<T> builder, string variableName, string timeoutValue, Func<ISendRequestSectionBuilder, ISectionPolicy> sendRequestBuilder) where T : IPolicySectionBuilder
+        {
+            return builder.SendRequest(attributesBuilder => attributesBuilder.Create(variableName, timeoutValue), sendRequestBuilder);
+        }
+
+        public static T SendRequest<T>(this ISendRequest<T> builder, string variableName, string timeoutValue, bool ignoreError, Func<ISendRequestSectionBuilder, ISectionPolicy> sendRequestBuilder) where T : IPolicySectionBuilder
+        {
+            return builder.SendRequest(attributesBuilder => attributesBuilder.Create(variableName, timeoutValue, ignoreError), sendRequestBuilder);
+        }
+
+        public static T SendRequest<T>(this ISendRequest<T> builder, string variableName, string timeoutValue, bool ignoreError, RequestMode requestMode, Func<ISendRequestSectionBuilder, ISectionPolicy> sendRequestBuilder) where T : IPolicySectionBuilder
+        {
+            return builder.SendRequest(attributesBuilder => attributesBuilder.Create(variableName, timeoutValue, ignoreError, requestMode), sendRequestBuilder);
         }
     }
 }

--- a/src/Oriflame.PolicyBuilder.Policies/Builders/Fluent/Attributes/ISendRequestAttributesBuilder.cs
+++ b/src/Oriflame.PolicyBuilder.Policies/Builders/Fluent/Attributes/ISendRequestAttributesBuilder.cs
@@ -11,6 +11,8 @@ namespace Oriflame.PolicyBuilder.Policies.Builders.Fluent.Attributes
 
         ISendRequestAttributesBuilder Timeout(TimeSpan time);
 
+        ISendRequestAttributesBuilder Timeout(string value);
+
         ISendRequestAttributesBuilder IgnoreError(bool value);
     }
 }

--- a/src/Oriflame.PolicyBuilder.Policies/Extensions/TimeSpanExtensions.cs
+++ b/src/Oriflame.PolicyBuilder.Policies/Extensions/TimeSpanExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Oriflame.PolicyBuilder.Xml.Extensions
+namespace Oriflame.PolicyBuilder.Policies.Extensions
 {
     public static class TimeSpanExtensions
     {

--- a/src/Oriflame.PolicyBuilder.Xml/Builders/Attributes/SendRequestAttributesBuilder.cs
+++ b/src/Oriflame.PolicyBuilder.Xml/Builders/Attributes/SendRequestAttributesBuilder.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Oriflame.PolicyBuilder.Policies.Builders.Enums;
 using Oriflame.PolicyBuilder.Policies.Builders.Fluent.Attributes;
-using Oriflame.PolicyBuilder.Xml.Extensions;
+using Oriflame.PolicyBuilder.Policies.Extensions;
 using Oriflame.PolicyBuilder.Xml.Mappers;
 
 namespace Oriflame.PolicyBuilder.Xml.Builders.Attributes
@@ -20,7 +20,12 @@ namespace Oriflame.PolicyBuilder.Xml.Builders.Attributes
 
         public ISendRequestAttributesBuilder Timeout(TimeSpan time)
         {
-            return AddAttribute("timeout", time.GetSeconds());
+            return Timeout(time.GetSeconds());
+        }
+
+        public ISendRequestAttributesBuilder Timeout(string value)
+        {
+            return AddAttribute("timeout", value);
         }
 
         public ISendRequestAttributesBuilder IgnoreError(bool value)

--- a/src/Oriflame.PolicyBuilder.Xml/Definitions/Common/CacheStore.cs
+++ b/src/Oriflame.PolicyBuilder.Xml/Definitions/Common/CacheStore.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Oriflame.PolicyBuilder.Xml.Extensions;
+using Oriflame.PolicyBuilder.Policies.Extensions;
 
 namespace Oriflame.PolicyBuilder.Xml.Definitions.Common
 {

--- a/src/Oriflame.PolicyBuilder.Xml/Definitions/Common/CacheStoreValue.cs
+++ b/src/Oriflame.PolicyBuilder.Xml/Definitions/Common/CacheStoreValue.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Oriflame.PolicyBuilder.Xml.Extensions;
+using Oriflame.PolicyBuilder.Policies.Extensions;
 
 namespace Oriflame.PolicyBuilder.Xml.Definitions.Common
 {

--- a/src/Oriflame.PolicyBuilder.Xml/Definitions/Common/ForwardRequest.cs
+++ b/src/Oriflame.PolicyBuilder.Xml/Definitions/Common/ForwardRequest.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Oriflame.PolicyBuilder.Xml.Extensions;
+using Oriflame.PolicyBuilder.Policies.Extensions;
 
 namespace Oriflame.PolicyBuilder.Xml.Definitions.Common
 {

--- a/src/Oriflame.PolicyBuilder.Xml/Definitions/Sections/RetryPolicy.cs
+++ b/src/Oriflame.PolicyBuilder.Xml/Definitions/Sections/RetryPolicy.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Oriflame.PolicyBuilder.Xml.Extensions;
+using Oriflame.PolicyBuilder.Policies.Extensions;
 using Oriflame.PolicyBuilder.Xml.Mappers;
 
 namespace Oriflame.PolicyBuilder.Xml.Definitions.Sections

--- a/tests/Oriflame.PolicyBuilder.Xml.Tests/Builders/Sections/RetrySectionBuilderTests.cs
+++ b/tests/Oriflame.PolicyBuilder.Xml.Tests/Builders/Sections/RetrySectionBuilderTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using FluentAssertions;
+using Oriflame.PolicyBuilder.Policies.Extensions;
 using Oriflame.PolicyBuilder.Xml.Definitions.Sections;
-using Oriflame.PolicyBuilder.Xml.Extensions;
 using Xunit;
 
 namespace Oriflame.PolicyBuilder.Xml.Tests.Builders.Sections


### PR DESCRIPTION
- `SendRequest` policy extension - `timeout` parameter can be defined as string