### PR TITLE
Get Body as JArray support for Request/Response

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 3.4.0
 
-- added `GetBodyAsJArray()` support to `ContextRequest` and `ContextResponse`
+- `ContextRequest` and `ContextResponse` - added support for getting body as JArray (`GetBodyAsJArray()` method)
 
 ## 3.3.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 3.4.0
+
+- added `GetBodyAsJArray()` support to `ContextRequest` and `ContextResponse`
+
 ## 3.3.0
 
 - `CacheStore` policy - added optional attribute builder - allows to set `cache-response` optional attribute

--- a/directory.build.props
+++ b/directory.build.props
@@ -7,7 +7,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>>https://github.com/Oriflame/PolicyBuilder</PackageProjectUrl>
     <Description>Policies generator for Azure API Management</Description>
-    <VersionPrefix>3.3.0</VersionPrefix>
+    <VersionPrefix>3.4.0</VersionPrefix>
     <VersionSuffix Condition="'$(VersionSuffix)'!=''">$(VersionSuffix)</VersionSuffix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>

--- a/src/Oriflame.PolicyBuilder.Xml/DynamicProperties/ContextRequest.cs
+++ b/src/Oriflame.PolicyBuilder.Xml/DynamicProperties/ContextRequest.cs
@@ -24,6 +24,11 @@ namespace Oriflame.PolicyBuilder.Xml.DynamicProperties
         {
             return $"{GetBody(true)}.As<string>({GetPreserveContentParameter(preserveContent)})".ToPolicyCode(inline);
         }
+        
+        public static string GetBodyAsJArray(bool inline = false, bool preserveContent = false)
+        {
+            return $"{GetBody(true)}.As<JArray>({GetPreserveContentParameter(preserveContent)})".ToPolicyCode(inline);
+        }
 
         public static string GetRouteParam(string paramName, bool inline = false)
         {

--- a/src/Oriflame.PolicyBuilder.Xml/DynamicProperties/ContextResponse.cs
+++ b/src/Oriflame.PolicyBuilder.Xml/DynamicProperties/ContextResponse.cs
@@ -21,6 +21,11 @@ namespace Oriflame.PolicyBuilder.Xml.DynamicProperties
         {
             return $"{Context}.Body.As<string>({ GetPreserveContentParameter(preserveContent) })".ToPolicyCode(inline);
         }
+        
+        public static string GetBodyAsJArray(bool inline = false, bool preserveContent = false)
+        {
+            return $"{Context}.Body.As<JArray>({ GetPreserveContentParameter(preserveContent) })".ToPolicyCode(inline);
+        }
 
         public static string GetStatusCode(bool inline = false)
         {

--- a/tests/Oriflame.PolicyBuilder.Xml.Tests/DynamicProperties/ContextRequestTests.cs
+++ b/tests/Oriflame.PolicyBuilder.Xml.Tests/DynamicProperties/ContextRequestTests.cs
@@ -41,6 +41,17 @@ namespace Oriflame.PolicyBuilder.Xml.Tests.DynamicProperties
             var policy = ContextRequest.GetBodyAsString(inline, preserveContent);
             policy.Should().Be(expected);
         }
+        
+        [Theory]
+        [InlineData(false, false, "@(context.Request.Body.As<JArray>())")]
+        [InlineData(true, false, "context.Request.Body.As<JArray>()")]
+        [InlineData(false, true, "@(context.Request.Body.As<JArray>(preserveContent: true))")]
+        [InlineData(true, true, "context.Request.Body.As<JArray>(preserveContent: true)")]
+        public void GetBodyAsJArrayGeneratesCorrectPolicy(bool inline, bool preserveContent, string expected)
+        {
+            var policy = ContextRequest.GetBodyAsJArray(inline, preserveContent);
+            policy.Should().Be(expected);
+        }
 
         [Theory]
         [InlineData("testingParam", false, "@(context.Request.MatchedParameters[\"testingParam\"])")]

--- a/tests/Oriflame.PolicyBuilder.Xml.Tests/DynamicProperties/ContextResponseTests.cs
+++ b/tests/Oriflame.PolicyBuilder.Xml.Tests/DynamicProperties/ContextResponseTests.cs
@@ -34,6 +34,17 @@ namespace Oriflame.PolicyBuilder.Xml.Tests.DynamicProperties
             var policy = ContextResponse.GetBodyAsString(inline, preserveContent);
             policy.Should().Be(expected);
         }
+        
+        [Theory]
+        [InlineData(false, false, "@(context.Response.Body.As<JArray>())")]
+        [InlineData(true, false, "context.Response.Body.As<JArray>()")]
+        [InlineData(false, true, "@(context.Response.Body.As<JArray>(preserveContent: true))")]
+        [InlineData(true, true, "context.Response.Body.As<JArray>(preserveContent: true)")]
+        public void GetBodyAsJArrayGeneratesCorrectPolicy(bool inline, bool preserveContent, string expected)
+        {
+            var policy = ContextResponse.GetBodyAsJArray(inline, preserveContent);
+            policy.Should().Be(expected);
+        }
 
         [Theory]
         [InlineData(false, "@(((IResponse)context.Response).StatusCode)")]


### PR DESCRIPTION
- `ContextRequest` and `ContextResponse` - added support for getting body as JArray (`GetBodyAsJArray()` method)