### PR TITLE
`ForwardRequest` policy - added optional attribute builder - allow to set `follow-redirects`, `buffer-request-body`, `buffer-response`, `fail-on-error-status-code`, `timeout` optional attributes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 4.2.0
 
-`ForwardRequest` policy - added optional attribute builder - allow to set `follow-redirects`, `buffer-request-body`, `buffer-response`, `fail-on-error-status-code` optional attributes
+`ForwardRequest` policy - added optional attribute builder - allow to set `follow-redirects`, `buffer-request-body`, `buffer-response`, `fail-on-error-status-code`, `timeout` optional attributes
 
 ## 4.1.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 4.2.0
+
+`ForwardRequest` policy - added optional attribute builder - allow to set `follow-redirects`, `buffer-request-body`, `buffer-response`, `fail-on-error-status-code` optional attributes
+
 ## 4.1.0
 
 - `ForwardRequest` policy - allows to set `buffer-response` optional attribute

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,19 @@
 
 - `ForwardRequest` policy - allows to set `buffer-response` optional attribute
 
+## 4.0.0
+
+- New policies `DeleteHeader` and `DeleteQueryParameter`
+- `ExistAction.Delete` marked as `Obsolete` - replaced with new policies `DeleteHeader` and `DeleteQueryParameter`
+
+## 3.6.0
+
+- `ContextVariable` extended with `GetValueOrDefault` method
+
+## 3.5.0
+
+- added new attribute `CachingType` to `CacheStoreValue` and `CacheLookupValue` policies
+
 ## 3.4.0
 
 - `ContextRequest` and `ContextResponse` - added support for getting body as JArray (`GetBodyAsJArray()` method)

--- a/directory.build.props
+++ b/directory.build.props
@@ -7,7 +7,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>>https://github.com/Oriflame/PolicyBuilder</PackageProjectUrl>
     <Description>Policies generator for Azure API Management</Description>
-    <VersionPrefix>4.1.0</VersionPrefix>
+    <VersionPrefix>4.2.0</VersionPrefix>
     <VersionSuffix Condition="'$(VersionSuffix)'!=''">$(VersionSuffix)</VersionSuffix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>

--- a/src/Oriflame.PolicyBuilder.Policies/Builders/Fluent/Attributes/IForwardRequestAttributesBuilder.cs
+++ b/src/Oriflame.PolicyBuilder.Policies/Builders/Fluent/Attributes/IForwardRequestAttributesBuilder.cs
@@ -1,7 +1,14 @@
-﻿namespace Oriflame.PolicyBuilder.Policies.Builders.Fluent.Attributes;
+﻿using System;
+
+namespace Oriflame.PolicyBuilder.Policies.Builders.Fluent.Attributes;
 
 public interface IForwardRequestAttributesBuilder : IAttributesBuilder
 {
+    /// <summary>
+    /// The amount of time in seconds to wait for the HTTP response headers to be returned by the backend service before a timeout error is raised
+    /// </summary>
+    IForwardRequestAttributesBuilder Timeout(TimeSpan timeout);
+    
     /// <summary>
     /// When set to true, triggers on-error section for response codes in the range from 400 to 599 inclusive
     /// </summary>

--- a/src/Oriflame.PolicyBuilder.Policies/Builders/Fluent/Attributes/IForwardRequestAttributesBuilder.cs
+++ b/src/Oriflame.PolicyBuilder.Policies/Builders/Fluent/Attributes/IForwardRequestAttributesBuilder.cs
@@ -1,0 +1,24 @@
+﻿namespace Oriflame.PolicyBuilder.Policies.Builders.Fluent.Attributes;
+
+public interface IForwardRequestAttributesBuilder : IAttributesBuilder
+{
+    /// <summary>
+    /// When set to true, triggers on-error section for response codes in the range from 400 to 599 inclusive
+    /// </summary>
+    IForwardRequestAttributesBuilder FailOnErrorStatusCode(bool value);
+
+    /// <summary>
+    /// Specifies whether redirects from the backend service are followed by the gateway or returned to the caller.
+    /// </summary>
+    IForwardRequestAttributesBuilder FollowRedirects(bool value);
+
+    /// <summary>
+    /// When set to true, request is buffered and will be reused on retry.
+    /// </summary>
+    IForwardRequestAttributesBuilder BufferRequestBody(bool value);
+
+    /// <summary>
+    /// Affects processing of chunked responses. When set to false, each chunk received from the backend is immediately returned to the caller. When set to true, chunks are buffered (8 KB, unless end of stream is detected) and only then returned to the caller.
+    /// </summary>
+    IForwardRequestAttributesBuilder BufferResponse(bool value);
+}

--- a/src/Oriflame.PolicyBuilder.Policies/Builders/Fluent/Sections/IBackendSectionPolicyBuilder.cs
+++ b/src/Oriflame.PolicyBuilder.Policies/Builders/Fluent/Sections/IBackendSectionPolicyBuilder.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using Oriflame.PolicyBuilder.Policies.Builders.Enums;
 using Oriflame.PolicyBuilder.Policies.Builders.Fluent.Actions;
+using Oriflame.PolicyBuilder.Policies.Builders.Fluent.Attributes;
 using Oriflame.PolicyBuilder.Policies.Definitions;
 using Oriflame.PolicyBuilder.Policies.DynamicProperties;
 
@@ -27,12 +29,12 @@ namespace Oriflame.PolicyBuilder.Policies.Builders.Fluent.Sections
         IBackendSectionPolicyBuilder SetBody(ILiquidTemplate template);
 
         /// <see href="https://docs.microsoft.com/en-us/azure/api-management/api-management-advanced-policies#ForwardRequest"/>
-        IBackendSectionPolicyBuilder ForwardRequest(TimeSpan? timeout, bool bufferTimeout);
-        
-        /// <see href="https://docs.microsoft.com/en-us/azure/api-management/api-management-advanced-policies#ForwardRequest"/>
         IBackendSectionPolicyBuilder ForwardRequest(TimeSpan? timeout);
 
         /// <see href="https://docs.microsoft.com/en-us/azure/api-management/api-management-advanced-policies#ForwardRequest"/>
         IBackendSectionPolicyBuilder ForwardRequest(string timeoutValue);
+        
+        /// <see href="https://docs.microsoft.com/en-us/azure/api-management/api-management-advanced-policies#ForwardRequest"/>
+        IBackendSectionPolicyBuilder ForwardRequest(TimeSpan? timeout, Func<IForwardRequestAttributesBuilder, IDictionary<string, string>> forwardRequestOptionalAttributesBuilder);
     }
 }

--- a/src/Oriflame.PolicyBuilder.Policies/Builders/Fluent/Sections/IBackendSectionPolicyBuilder.cs
+++ b/src/Oriflame.PolicyBuilder.Policies/Builders/Fluent/Sections/IBackendSectionPolicyBuilder.cs
@@ -29,12 +29,14 @@ namespace Oriflame.PolicyBuilder.Policies.Builders.Fluent.Sections
         IBackendSectionPolicyBuilder SetBody(ILiquidTemplate template);
 
         /// <see href="https://docs.microsoft.com/en-us/azure/api-management/api-management-advanced-policies#ForwardRequest"/>
+        [Obsolete("Use method nameof(ForwardRequest) with optional parameters builder instead.")]
         IBackendSectionPolicyBuilder ForwardRequest(TimeSpan? timeout);
 
         /// <see href="https://docs.microsoft.com/en-us/azure/api-management/api-management-advanced-policies#ForwardRequest"/>
+        [Obsolete("Use method nameof(ForwardRequest) with optional parameters builder instead.")]
         IBackendSectionPolicyBuilder ForwardRequest(string timeoutValue);
         
         /// <see href="https://docs.microsoft.com/en-us/azure/api-management/api-management-advanced-policies#ForwardRequest"/>
-        IBackendSectionPolicyBuilder ForwardRequest(TimeSpan? timeout, Func<IForwardRequestAttributesBuilder, IDictionary<string, string>> forwardRequestOptionalAttributesBuilder);
+        IBackendSectionPolicyBuilder ForwardRequest(Func<IForwardRequestAttributesBuilder, IDictionary<string, string>> forwardRequestOptionalAttributesBuilder);
     }
 }

--- a/src/Oriflame.PolicyBuilder.Xml/Builders/Attributes/ForwardRequestAttributesBuilder.cs
+++ b/src/Oriflame.PolicyBuilder.Xml/Builders/Attributes/ForwardRequestAttributesBuilder.cs
@@ -1,0 +1,26 @@
+﻿using Oriflame.PolicyBuilder.Policies.Builders.Fluent.Attributes;
+
+namespace Oriflame.PolicyBuilder.Xml.Builders.Attributes;
+
+public class ForwardRequestAttributesBuilder : AttributesBuilderBase<IForwardRequestAttributesBuilder>, IForwardRequestAttributesBuilder
+{
+    public IForwardRequestAttributesBuilder FailOnErrorStatusCode(bool value)
+    {
+        return AddAttribute("fail-on-error-status-code", value);
+    }
+
+    public IForwardRequestAttributesBuilder FollowRedirects(bool value)
+    {
+        return AddAttribute("follow-redirects", value);
+    }
+
+    public IForwardRequestAttributesBuilder BufferRequestBody(bool value)
+    {
+        return AddAttribute("buffer-request-body", value);
+    }
+
+    public IForwardRequestAttributesBuilder BufferResponse(bool value)
+    {
+        return AddAttribute("buffer-response", value);
+    }
+}

--- a/src/Oriflame.PolicyBuilder.Xml/Builders/Attributes/ForwardRequestAttributesBuilder.cs
+++ b/src/Oriflame.PolicyBuilder.Xml/Builders/Attributes/ForwardRequestAttributesBuilder.cs
@@ -1,9 +1,17 @@
-﻿using Oriflame.PolicyBuilder.Policies.Builders.Fluent.Attributes;
+﻿using System;
+using Castle.Components.DictionaryAdapter.Xml;
+using Oriflame.PolicyBuilder.Policies.Builders.Fluent.Attributes;
+using Oriflame.PolicyBuilder.Policies.Extensions;
 
 namespace Oriflame.PolicyBuilder.Xml.Builders.Attributes;
 
 public class ForwardRequestAttributesBuilder : AttributesBuilderBase<IForwardRequestAttributesBuilder>, IForwardRequestAttributesBuilder
 {
+    public IForwardRequestAttributesBuilder Timeout(TimeSpan timeout)
+    {
+        return AddAttribute("timeout", timeout.GetSeconds());
+    }
+
     public IForwardRequestAttributesBuilder FailOnErrorStatusCode(bool value)
     {
         return AddAttribute("fail-on-error-status-code", value);

--- a/src/Oriflame.PolicyBuilder.Xml/Builders/Sections/BackendSectionPolicyBuilder.ForwardRequest.cs
+++ b/src/Oriflame.PolicyBuilder.Xml/Builders/Sections/BackendSectionPolicyBuilder.ForwardRequest.cs
@@ -1,22 +1,27 @@
 ﻿using System;
+using System.Collections.Generic;
+using Oriflame.PolicyBuilder.Policies.Builders.Fluent.Attributes;
 using Oriflame.PolicyBuilder.Policies.Builders.Fluent.Sections;
 using Oriflame.PolicyBuilder.Xml.Definitions.Common;
 using Oriflame.PolicyBuilder.Policies.Extensions;
+using Oriflame.PolicyBuilder.Xml.Builders.Attributes;
 
 namespace Oriflame.PolicyBuilder.Xml.Builders.Sections
 {
     public partial class BackendSectionPolicyBuilder : SectionBuilderBase<IBackendSectionPolicyBuilder>, IBackendSectionPolicyBuilder
     {
-        /// <inheritdoc />
-        public virtual IBackendSectionPolicyBuilder ForwardRequest(TimeSpan? timeout, bool bufferResponse)
+        public virtual IBackendSectionPolicyBuilder ForwardRequest(TimeSpan? timeout, Func<IForwardRequestAttributesBuilder, IDictionary<string, string>> forwardRequestOptionalAttributesBuilder)
         {
-            return AddPolicyDefinition(new ForwardRequest(timeout?.GetSeconds(), bufferResponse));
+            var attributesBuilder = new ForwardRequestAttributesBuilder();
+            var attributes = forwardRequestOptionalAttributesBuilder?.Invoke(attributesBuilder);
+            var policy = new ForwardRequest(timeout?.GetSeconds(), attributes);
+            return AddPolicyDefinition(policy);
         }
         
         /// <inheritdoc />
         public virtual IBackendSectionPolicyBuilder ForwardRequest(TimeSpan? timeout)
         {
-            return AddPolicyDefinition(new ForwardRequest(timeout));
+            return AddPolicyDefinition(new ForwardRequest(timeout?.GetSeconds()));
         }
 
         /// <inheritdoc />

--- a/src/Oriflame.PolicyBuilder.Xml/Builders/Sections/BackendSectionPolicyBuilder.ForwardRequest.cs
+++ b/src/Oriflame.PolicyBuilder.Xml/Builders/Sections/BackendSectionPolicyBuilder.ForwardRequest.cs
@@ -3,31 +3,30 @@ using System.Collections.Generic;
 using Oriflame.PolicyBuilder.Policies.Builders.Fluent.Attributes;
 using Oriflame.PolicyBuilder.Policies.Builders.Fluent.Sections;
 using Oriflame.PolicyBuilder.Xml.Definitions.Common;
-using Oriflame.PolicyBuilder.Policies.Extensions;
 using Oriflame.PolicyBuilder.Xml.Builders.Attributes;
 
 namespace Oriflame.PolicyBuilder.Xml.Builders.Sections
 {
     public partial class BackendSectionPolicyBuilder : SectionBuilderBase<IBackendSectionPolicyBuilder>, IBackendSectionPolicyBuilder
     {
-        public virtual IBackendSectionPolicyBuilder ForwardRequest(TimeSpan? timeout, Func<IForwardRequestAttributesBuilder, IDictionary<string, string>> forwardRequestOptionalAttributesBuilder)
+        public virtual IBackendSectionPolicyBuilder ForwardRequest(Func<IForwardRequestAttributesBuilder, IDictionary<string, string>> forwardRequestOptionalAttributesBuilder)
         {
             var attributesBuilder = new ForwardRequestAttributesBuilder();
             var attributes = forwardRequestOptionalAttributesBuilder?.Invoke(attributesBuilder);
-            var policy = new ForwardRequest(timeout?.GetSeconds(), attributes);
+            var policy = new ForwardRequest(attributes);
             return AddPolicyDefinition(policy);
         }
         
         /// <inheritdoc />
         public virtual IBackendSectionPolicyBuilder ForwardRequest(TimeSpan? timeout)
         {
-            return AddPolicyDefinition(new ForwardRequest(timeout?.GetSeconds()));
+            return timeout.HasValue ? ForwardRequest(builder => builder.Timeout(timeout.Value).Create()) : ForwardRequest(builder => builder.Create());
         }
 
         /// <inheritdoc />
         public virtual IBackendSectionPolicyBuilder ForwardRequest(string timeoutValue)
         {
-            return AddPolicyDefinition(new ForwardRequest(timeoutValue));
+            return ForwardRequest(TimeSpan.FromSeconds(Convert.ToInt32(timeoutValue)));
         }
     }
 }

--- a/src/Oriflame.PolicyBuilder.Xml/Definitions/Common/ForwardRequest.cs
+++ b/src/Oriflame.PolicyBuilder.Xml/Definitions/Common/ForwardRequest.cs
@@ -1,25 +1,17 @@
 ﻿using System;
+using System.Collections.Generic;
 using Oriflame.PolicyBuilder.Policies.Extensions;
-using Oriflame.PolicyBuilder.Xml.Mappers;
 
 namespace Oriflame.PolicyBuilder.Xml.Definitions.Common
 {
     public class ForwardRequest : PolicyXmlBase
     {
-        public ForwardRequest(TimeSpan? timeout) : this(timeout?.GetSeconds())
-        {
-        }
-        
-        public ForwardRequest(string timeoutValue, bool? bufferResponse = null) : base("forward-request")
+       
+        public ForwardRequest(string timeoutValue, IDictionary<string, string> attributes = null) : base("forward-request", attributes)
         {
             if (!string.IsNullOrEmpty(timeoutValue))
             {
                 Attributes.Add("timeout", timeoutValue);
-            }
-
-            if (bufferResponse.HasValue)
-            {
-                Attributes.Add("buffer-response", BoolMapper.Map(bufferResponse.Value));
             }
         }
     }

--- a/src/Oriflame.PolicyBuilder.Xml/Definitions/Common/ForwardRequest.cs
+++ b/src/Oriflame.PolicyBuilder.Xml/Definitions/Common/ForwardRequest.cs
@@ -6,13 +6,8 @@ namespace Oriflame.PolicyBuilder.Xml.Definitions.Common
 {
     public class ForwardRequest : PolicyXmlBase
     {
-       
-        public ForwardRequest(string timeoutValue, IDictionary<string, string> attributes = null) : base("forward-request", attributes)
+        public ForwardRequest(IDictionary<string, string> attributes) : base("forward-request", attributes)
         {
-            if (!string.IsNullOrEmpty(timeoutValue))
-            {
-                Attributes.Add("timeout", timeoutValue);
-            }
         }
     }
 }

--- a/tests/Oriflame.PolicyBuilder.Xml.Tests/Builders/Sections/BackendSectionPolicyBuilderTests.cs
+++ b/tests/Oriflame.PolicyBuilder.Xml.Tests/Builders/Sections/BackendSectionPolicyBuilderTests.cs
@@ -14,12 +14,13 @@ namespace Oriflame.PolicyBuilder.Xml.Tests.Builders.Sections
             const int timeout = 5;
             
             var policyBuilder = new BackendSectionPolicyBuilder(new SectionPolicy("backend"))
-                .ForwardRequest(TimeSpan.FromSeconds(timeout),
+                .ForwardRequest(
                     x => x
                         .BufferResponse(true)
                         .FollowRedirects(false)
                         .FailOnErrorStatusCode(true)
                         .BufferRequestBody(true)
+                        .Timeout(TimeSpan.FromSeconds(timeout))
                         .Create()
                 );
             var policy = (SectionPolicy)policyBuilder.Create();
@@ -32,12 +33,28 @@ namespace Oriflame.PolicyBuilder.Xml.Tests.Builders.Sections
         }
         
         [Fact]
-        public void CreatesForwardRequestPolicy()
+        public void CreatesForwardRequestPolicyFromTimespanTimeout()
         {
             const int timeout = 5;
             
             var policyBuilder = new BackendSectionPolicyBuilder(new SectionPolicy("backend"))
                 .ForwardRequest(TimeSpan.FromSeconds(timeout));
+            var policy = (SectionPolicy)policyBuilder.Create();
+            var xml = policy.GetXml().ToString();
+
+            xml.Should().Be(
+                $@"<backend>
+  <forward-request timeout=""{timeout}"" />
+</backend>");
+        }
+        
+        [Fact]
+        public void CreatesForwardRequestPolicyFromStringTimeout()
+        {
+            const int timeout = 5;
+            
+            var policyBuilder = new BackendSectionPolicyBuilder(new SectionPolicy("backend"))
+                .ForwardRequest(timeout.ToString());
             var policy = (SectionPolicy)policyBuilder.Create();
             var xml = policy.GetXml().ToString();
 

--- a/tests/Oriflame.PolicyBuilder.Xml.Tests/Builders/Sections/BackendSectionPolicyBuilderTests.cs
+++ b/tests/Oriflame.PolicyBuilder.Xml.Tests/Builders/Sections/BackendSectionPolicyBuilderTests.cs
@@ -2,24 +2,26 @@
 using FluentAssertions;
 using Oriflame.PolicyBuilder.Xml.Builders.Sections;
 using Oriflame.PolicyBuilder.Xml.Definitions.Sections;
+using Oriflame.PolicyBuilder.Xml.Mappers;
 using Xunit;
 
 namespace Oriflame.PolicyBuilder.Xml.Tests.Builders.Sections
 {
     public class BackendSectionPolicyBuilderTests
     {
-        [Fact]
-        public void CreatesForwardRequestPolicyWithAttributes()
+        [Theory]
+        [InlineData(5, true, false, false, true)]
+        [InlineData(2, false, false, false, false)]
+        [InlineData(1, true, true, true, true)]
+        public void CreatesForwardRequestPolicyWithAttributes(int timeout, bool bufferResponse, bool followRedirects, bool failOnErrorStatusCode, bool bufferRequestBody)
         {
-            const int timeout = 5;
-            
             var policyBuilder = new BackendSectionPolicyBuilder(new SectionPolicy("backend"))
                 .ForwardRequest(
                     x => x
-                        .BufferResponse(true)
-                        .FollowRedirects(false)
-                        .FailOnErrorStatusCode(true)
-                        .BufferRequestBody(true)
+                        .BufferResponse(bufferResponse)
+                        .FollowRedirects(followRedirects)
+                        .FailOnErrorStatusCode(failOnErrorStatusCode)
+                        .BufferRequestBody(bufferRequestBody)
                         .Timeout(TimeSpan.FromSeconds(timeout))
                         .Create()
                 );
@@ -28,7 +30,7 @@ namespace Oriflame.PolicyBuilder.Xml.Tests.Builders.Sections
 
             xml.Should().Be(
                 $@"<backend>
-  <forward-request buffer-response=""true"" follow-redirects=""false"" fail-on-error-status-code=""true"" buffer-request-body=""true"" timeout=""{timeout}"" />
+  <forward-request buffer-response=""{BoolMapper.Map(bufferResponse)}"" follow-redirects=""{BoolMapper.Map(followRedirects)}"" fail-on-error-status-code=""{BoolMapper.Map(failOnErrorStatusCode)}"" buffer-request-body=""{BoolMapper.Map(bufferRequestBody)}"" timeout=""{timeout}"" />
 </backend>");
         }
         

--- a/tests/Oriflame.PolicyBuilder.Xml.Tests/Builders/Sections/BackendSectionPolicyBuilderTests.cs
+++ b/tests/Oriflame.PolicyBuilder.Xml.Tests/Builders/Sections/BackendSectionPolicyBuilderTests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using FluentAssertions;
+using Oriflame.PolicyBuilder.Xml.Builders.Sections;
+using Oriflame.PolicyBuilder.Xml.Definitions.Sections;
+using Xunit;
+
+namespace Oriflame.PolicyBuilder.Xml.Tests.Builders.Sections
+{
+    public class BackendSectionPolicyBuilderTests
+    {
+        [Fact]
+        public void CreatesForwardRequestPolicyWithAttributes()
+        {
+            const int timeout = 5;
+            
+            var policyBuilder = new BackendSectionPolicyBuilder(new SectionPolicy("backend"))
+                .ForwardRequest(TimeSpan.FromSeconds(timeout),
+                    x => x
+                        .BufferResponse(true)
+                        .FollowRedirects(false)
+                        .FailOnErrorStatusCode(true)
+                        .BufferRequestBody(true)
+                        .Create()
+                );
+            var policy = (SectionPolicy)policyBuilder.Create();
+            var xml = policy.GetXml().ToString();
+
+            xml.Should().Be(
+                $@"<backend>
+  <forward-request buffer-response=""true"" follow-redirects=""false"" fail-on-error-status-code=""true"" buffer-request-body=""true"" timeout=""{timeout}"" />
+</backend>");
+        }
+        
+        [Fact]
+        public void CreatesForwardRequestPolicy()
+        {
+            const int timeout = 5;
+            
+            var policyBuilder = new BackendSectionPolicyBuilder(new SectionPolicy("backend"))
+                .ForwardRequest(TimeSpan.FromSeconds(timeout));
+            var policy = (SectionPolicy)policyBuilder.Create();
+            var xml = policy.GetXml().ToString();
+
+            xml.Should().Be(
+                $@"<backend>
+  <forward-request timeout=""{timeout}"" />
+</backend>");
+        }
+    }
+}

--- a/tests/Oriflame.PolicyBuilder.Xml.Tests/Definitions/Common/ForwardRequestsTests.cs
+++ b/tests/Oriflame.PolicyBuilder.Xml.Tests/Definitions/Common/ForwardRequestsTests.cs
@@ -7,9 +7,8 @@ namespace Oriflame.PolicyBuilder.Xml.Tests.Definitions.Common
 {
     public class ForwardRequestsTests
     {
-        [Theory]
-        [InlineData("5")]
-        public void CreatesCorrectPolicy(string timeoutSeconds)
+        [Fact]
+        public void CreatesCorrectPolicy()
         {
             var basePolicy = new ForwardRequest(new Dictionary<string, string>());
             var xml = basePolicy.GetXml().ToString();

--- a/tests/Oriflame.PolicyBuilder.Xml.Tests/Definitions/Common/ForwardRequestsTests.cs
+++ b/tests/Oriflame.PolicyBuilder.Xml.Tests/Definitions/Common/ForwardRequestsTests.cs
@@ -8,22 +8,12 @@ namespace Oriflame.PolicyBuilder.Xml.Tests.Definitions.Common
     public class ForwardRequestsTests
     {
         [Theory]
-        [InlineData(5)]
-        public void CreatesCorrectPolicy(int timeoutSeconds)
+        [InlineData("5")]
+        public void CreatesCorrectPolicy(string timeoutSeconds)
         {
-            var basePolicy = new ForwardRequest(TimeSpan.FromSeconds(timeoutSeconds));
+            var basePolicy = new ForwardRequest(timeoutSeconds);
             var xml = basePolicy.GetXml().ToString();
             xml.Should().Be($"<forward-request timeout=\"{timeoutSeconds}\" />");
-        }
-        
-        [Theory]
-        [InlineData(5, true)]
-        [InlineData(3, false)]
-        public void CreatesCorrectBufferResponsePolicy(int timeoutSeconds, bool bufferResponse)
-        {
-            var basePolicy = new ForwardRequest(timeoutSeconds.ToString(), bufferResponse);
-            var xml = basePolicy.GetXml().ToString();
-            xml.Should().Be($"<forward-request timeout=\"{timeoutSeconds}\" buffer-response=\"{bufferResponse.ToString().ToLower()}\" />");
         }
     }
 }

--- a/tests/Oriflame.PolicyBuilder.Xml.Tests/Definitions/Common/ForwardRequestsTests.cs
+++ b/tests/Oriflame.PolicyBuilder.Xml.Tests/Definitions/Common/ForwardRequestsTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using System.Collections.Generic;
 using FluentAssertions;
 using Oriflame.PolicyBuilder.Xml.Definitions.Common;
 using Xunit;
@@ -11,9 +11,9 @@ namespace Oriflame.PolicyBuilder.Xml.Tests.Definitions.Common
         [InlineData("5")]
         public void CreatesCorrectPolicy(string timeoutSeconds)
         {
-            var basePolicy = new ForwardRequest(timeoutSeconds);
+            var basePolicy = new ForwardRequest(new Dictionary<string, string>());
             var xml = basePolicy.GetXml().ToString();
-            xml.Should().Be($"<forward-request timeout=\"{timeoutSeconds}\" />");
+            xml.Should().Be($"<forward-request />");
         }
     }
 }


### PR DESCRIPTION
`ForwardRequest` policy - added optional attribute builder - allow to set `follow-redirects`, `buffer-request-body`, `buffer-response`, `fail-on-error-status-code` optional attributes