### PR TITLE
Make the policy builder generator's fixtures overridable

### DIFF
--- a/src/Oriflame.PolicyBuilder.Generator/Generator.cs
+++ b/src/Oriflame.PolicyBuilder.Generator/Generator.cs
@@ -26,7 +26,7 @@ namespace Oriflame.PolicyBuilder.Generator
 
         protected abstract void GenerateOutput(string outputDirectory, Assembly assembly);
 
-        protected static Fixture GetCustomFixture()
+        protected virtual Fixture GetCustomFixture()
         {
             var fixture = new Fixture();
             fixture.Customize(new ApiControllerCustomization());


### PR DESCRIPTION
Currently there isn't a way to inherit from the `PoliciesGenerator` and easily override its fixtures, since the `GetCustomFixture` method is set as `protected static`. This pull request changes that.